### PR TITLE
Fix spelling of threshold

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -33,7 +33,7 @@
             },
             {
                 "key": "ActivityThreshold",
-                "display_name": "Activity threashold",
+                "display_name": "Activity threshold",
                 "help_text": "When the bot recommends you the most active channels, what is the time (in minutes) that is used to count activity. By default is a week. In instances with a lot of activity we recommend to adjust this to smaller value.",
                 "type": "number"
             },

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -51,7 +51,7 @@ const manifestStr = `
       },
       {
         "key": "ActivityThreshold",
-        "display_name": "Activity threashold",
+        "display_name": "Activity threshold",
         "type": "number",
         "help_text": "When the bot recommends you the most active channels, what is the time (in minutes) that is used to count activity. By default is a week. In instances with a lot of activity we recommend to adjust this to smaller value.",
         "placeholder": "",


### PR DESCRIPTION
Correct the spelling in the display of the setting ''Activity threshold`:

![Screenshot from 2022-07-11 17-56-03](https://user-images.githubusercontent.com/881988/178306377-8e2bfbcc-f1a3-4d21-9d00-e14a5dce5d6d.png)
